### PR TITLE
Add support for multiple workers in same repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,13 @@ steps:
       uses: jdmevo123/akamai-edgeworker-action@1.0
       env:
         EDGERC: ${{ secrets.AKAMAI_EDGERC }}
+        WORKER_DIR: workerdirname # Optional directory for worker code (relative)
       with:
         edgeworkersName: ${{ github.event.repository.name }}
         network: 'staging'
         groupid: '12345' #Akamai GroupID used for registering new edgeworkers
 ```
+
 ## License
 
 This project is distributed under the [MIT license](LICENSE.md).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -o pipefail
 
+env
+echo ${GITHUB_WORKSPACE}
+ls -althr ${GITHUB_WORKSPACE}
+
 # Create /root/.edgerc file from env variable
 echo -e "${EDGERC}" > ~/.edgerc
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,6 @@ response=$(akamai edgeworkers list-ids --json --section edgeworkers --edgerc ~/.
 edgeworkerList=$( cat ${response} )
 edgeworkersID=$(echo ${edgeworkerList} | jq --arg edgeworkersName "${edgeworkersName}" '.data[] | select(.name == $edgeworkersName) | .edgeWorkerId')
 edgeworkersgroupIude=$(echo $edgeworkerList | jq --arg edgeworkersName "$edgeworkersName" '.data[] | select(.name == $edgeworkersName) | .groupId')
-cd $GITHUB_WORKSPACE
 
 tarCommand='tar -czvf ~/deploy.tar.gz'
 # check if needed files exist
@@ -51,7 +50,7 @@ if [ -n "$edgeworkersID" ]; then
      --section edgeworkers \
      --bundle ~/deploy.tar.gz \
      ${edgeworkersID})
-   edgeworkersVersion=$(echo $(<$GITHUB_WORKSPACE/bundle.json) | jq '.["edgeworker-version"]' | tr -d '"')
+   edgeworkersVersion=$(echo $(<$bundle.json) | jq '.["edgeworker-version"]' | tr -d '"')
    echo "Activating Edgeworker Version: ${edgeworkersVersion}"
    #ACTIVATE  edgeworker
    echo "activating"
@@ -100,7 +99,7 @@ if [ -z "$edgeworkersID" ]; then
       --section edgeworkers \
       --bundle ~/deploy.tar.gz \
       ${edgeworkersID})
-    edgeworkersVersion=$(echo $(<$GITHUB_WORKSPACE/bundle.json) | jq '.["edgeworker-version"]' | tr -d '"')
+    edgeworkersVersion=$(echo $(<$bundle.json) | jq '.["edgeworker-version"]' | tr -d '"')
     echo "Activating Edgeworker Version: ${edgeworkersVersion}"
      #ACTIVATE  edgeworker
     echo "activating"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -o pipefail
 
-env
-echo ${GITHUB_WORKSPACE}
-ls -althr ${GITHUB_WORKSPACE}
-
 # Create /root/.edgerc file from env variable
 echo -e "${EDGERC}" > ~/.edgerc
 
@@ -18,7 +14,12 @@ response=$(akamai edgeworkers list-ids --json --section edgeworkers --edgerc ~/.
 edgeworkerList=$( cat ${response} )
 edgeworkersID=$(echo ${edgeworkerList} | jq --arg edgeworkersName "${edgeworkersName}" '.data[] | select(.name == $edgeworkersName) | .edgeWorkerId')
 edgeworkersgroupIude=$(echo $edgeworkerList | jq --arg edgeworkersName "$edgeworkersName" '.data[] | select(.name == $edgeworkersName) | .groupId')
-cd $GITHUB_WORKSPACE
+
+if [ -n "${WORKER_DIR}" ]; then
+  GITHUB_WORKSPACE="${GITHUB_WORKSPACE}/${WORKER_DIR}"
+fi
+
+cd ${GITHUB_WORKSPACE}
 
 tarCommand='tar -czvf ~/deploy.tar.gz'
 # check if needed files exist

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ response=$(akamai edgeworkers list-ids --json --section edgeworkers --edgerc ~/.
 edgeworkerList=$( cat ${response} )
 edgeworkersID=$(echo ${edgeworkerList} | jq --arg edgeworkersName "${edgeworkersName}" '.data[] | select(.name == $edgeworkersName) | .edgeWorkerId')
 edgeworkersgroupIude=$(echo $edgeworkerList | jq --arg edgeworkersName "$edgeworkersName" '.data[] | select(.name == $edgeworkersName) | .groupId')
+cd $GITHUB_WORKSPACE
 
 tarCommand='tar -czvf ~/deploy.tar.gz'
 # check if needed files exist
@@ -54,7 +55,7 @@ if [ -n "$edgeworkersID" ]; then
      --section edgeworkers \
      --bundle ~/deploy.tar.gz \
      ${edgeworkersID})
-   edgeworkersVersion=$(echo $(<$bundle.json) | jq '.["edgeworker-version"]' | tr -d '"')
+   edgeworkersVersion=$(echo $(<$GITHUB_WORKSPACE/bundle.json) | jq '.["edgeworker-version"]' | tr -d '"')
    echo "Activating Edgeworker Version: ${edgeworkersVersion}"
    #ACTIVATE  edgeworker
    echo "activating"
@@ -103,7 +104,7 @@ if [ -z "$edgeworkersID" ]; then
       --section edgeworkers \
       --bundle ~/deploy.tar.gz \
       ${edgeworkersID})
-    edgeworkersVersion=$(echo $(<$bundle.json) | jq '.["edgeworker-version"]' | tr -d '"')
+    edgeworkersVersion=$(echo $(<$GITHUB_WORKSPACE/bundle.json) | jq '.["edgeworker-version"]' | tr -d '"')
     echo "Activating Edgeworker Version: ${edgeworkersVersion}"
      #ACTIVATE  edgeworker
     echo "activating"


### PR DESCRIPTION
We have multiple edge workers in one repository. Each worker is located in its own sub-directory.
We needed a way to specify which worker to deploy, so we added an optional `WORKER_DIR` parameter, which specifies the directory that the worker is located in.
It would be great to have this change upstream so that we don't have to maintain a fork of the action. 
